### PR TITLE
refactor(gasi): `string`을 직접 받지 않도록 스키마 수정

### DIFF
--- a/apps/gasi/src/mockUtils.ts
+++ b/apps/gasi/src/mockUtils.ts
@@ -1,0 +1,44 @@
+import type { ReviewEntry, ReviewResult } from "@request/specs";
+
+export const createMockAssignment = (id: string, name: string) => ({
+  id,
+  name,
+  description: "테스트용 과제입니다. 풀 수 있을까요?",
+  readme: `# 테스트용 과제
+테스트용 과제입니다. 마크다운 렌더링이 잘 될까요? \`안녕하세요\`
+**안녕하세요** ~안녕하세요~
+> 안녕하세요 ㅎㅎ
+
+`,
+  prompt: {
+    fields: ["프론트엔드", "서버/백엔드"],
+    techs: ["Spring Boot", "Rust"],
+    companies: ["kakao", "goorm"],
+  },
+  status: "READY",
+  lastUpdated: new Date().toISOString(),
+});
+
+export const createMockReviewEntry = (
+  name: string,
+  scenario: string,
+  path: string | undefined,
+  lineRange: [number, number] | undefined,
+): ReviewEntry => {
+  const score = Math.floor(Math.random() * 100);
+  const result = Math.floor(score / 50);
+  return {
+    name,
+    scenario,
+    result: ["FAIL", "NEUTRAL", "GOOD"][result] as ReviewResult,
+    score,
+    message:
+      result === 2
+        ? "가수의 실력이시네요~"
+        : result === 1
+          ? "조금만 더 신나게 불러보세요!"
+          : "진짜 못들어주겠네요~",
+    ...(path && { path }),
+    ...(lineRange && { lineRange }),
+  };
+};

--- a/apps/gasi/src/router.ts
+++ b/apps/gasi/src/router.ts
@@ -115,13 +115,13 @@ export const appRouter = t.router({
         };
       }),
       // 과제 ID로 과제 세부사항을 봅니다.
-      get: p.input(z.string()).query(({ input }) => {
-        if (input === "none")
+      get: p.input(z.object({ id: z.string() })).query(({ input }) => {
+        if (input.id === "none")
           throw new TRPCError({
             code: "NOT_FOUND",
             message: "해당 ID의 과제를 찾을 수 없습니다.",
           });
-        return createMockAssignment(input, "테스트과제 - id none으로 하면 오류남");
+        return createMockAssignment(input.id, "테스트과제 - id none으로 하면 오류남");
       }),
       // 과제 생성 요청을 합니다. 계정당 하나만 진행할 수 있습니다.
       generate: p.input(AssignmentPromptSchema).mutation(({ input }) => ({
@@ -146,11 +146,11 @@ export const appRouter = t.router({
         }),
       ),
       // 과제 시도를 취소합니다.
-      cancel: p.input(z.string()).mutation((): string => {
+      cancel: p.input(z.object({ id: z.string() })).mutation((): string => {
         return humanId({ separator: "-", capitalize: false });
       }),
       // 제출물의 파일 목록을 트리 형태로 반환합니다.
-      files: p.input(z.string()).query((): ReviewFileTree[] => [
+      files: p.input(z.object({ id: z.string() })).query((): ReviewFileTree[] => [
         {
           name: "src",
           type: "directory",
@@ -190,9 +190,9 @@ export const TestSchema = z.object({ name: z.string(), });`,
           createMockReviewEntry("라인 채점 항목", "lint", "src/index.js", [10, 13]),
         ]),
       // 리뷰의 기본 정보를 반환합니다.
-      review: p.input(z.string()).query(
+      review: p.input(z.object({ id: z.string() })).query(
         ({ input }): Omit<Review, "entries"> => ({
-          id: input,
+          id: input.id,
           status: "DONE",
           scenarios: [
             {

--- a/apps/gasi/src/router.ts
+++ b/apps/gasi/src/router.ts
@@ -18,197 +18,47 @@ import {
 import { TRPCError } from "@trpc/server";
 import { humanId } from "human-id";
 import z from "zod";
-import { kakao } from "./routes/auth.js";
+import { createMockAssignment, createMockReviewEntry } from "./mockUtils.js";
+import { generate, get, list } from "./routes/asgmt.js";
+import { kakao, register } from "./routes/auth.js";
+import { cancel, file, files, init, review, reviewEntries } from "./routes/submission.js";
+import { me } from "./routes/user.js";
 import { p, t } from "./trpc.js";
-
-const createMockAssignment = (id: string, name: string) => ({
-  id,
-  name,
-  description: "테스트용 과제입니다. 풀 수 있을까요?",
-  readme: `# 테스트용 과제
-테스트용 과제입니다. 마크다운 렌더링이 잘 될까요? \`안녕하세요\`
-**안녕하세요** ~안녕하세요~
-> 안녕하세요 ㅎㅎ
-
-`,
-  prompt: {
-    fields: ["프론트엔드", "서버/백엔드"],
-    techs: ["Spring Boot", "Rust"],
-    companies: ["kakao", "goorm"],
-  },
-  status: "READY",
-  lastUpdated: new Date().toISOString(),
-});
-
-const createMockReviewEntry = (
-  name: string,
-  scenario: string,
-  path: string | undefined,
-  lineRange: [number, number] | undefined,
-): ReviewEntry => {
-  const score = Math.floor(Math.random() * 100);
-  const result = Math.floor(score / 50);
-  return {
-    name,
-    scenario,
-    result: ["FAIL", "NEUTRAL", "GOOD"][result] as ReviewResult,
-    score,
-    message:
-      result === 2
-        ? "가수의 실력이시네요~"
-        : result === 1
-          ? "조금만 더 신나게 불러보세요!"
-          : "진짜 못들어주겠네요~",
-    ...(path && { path }),
-    ...(lineRange && { lineRange }),
-  };
-};
 
 // https://trpc.io/docs/server/server-side-calls 참고하세용
 export const appRouter = t.router({
   v1: {
     auth: {
       // Kakao 로그인 code를 받고 accessToken을 리턴합니다.
-      kakao: kakao,
+      kakao,
       // 최초 로그인 유저의 정보를 받습니다.
-      register: p.input(RegisterUserRequestSchema).mutation(() => {}),
+      register,
     },
     user: {
       // 자신의 정보를 반환합니다.
-      me: p.query(
-        (): User => ({
-          id: "673f25db6a52140e5bc47f75",
-          name: "구효민",
-          email: "hyomin@soongsil.ac.kr",
-          registered: true,
-          providers: {
-            kakao: {
-              uid: "230549202",
-              connectedAt: "2024-11-21T12:25:34.710Z",
-            },
-          },
-          submissions: [],
-          prompt: {
-            fields: ["프론트엔드", "서버/백엔드"],
-            techs: ["Spring Boot", "Rust"],
-            companies: ["kakao", "goorm"],
-          },
-        }),
-      ),
+      me,
     },
     asgmt: {
       // 생성 완료된 전체 과제 목록을 표시합니다.
-      list: p.input(AssignmentFilterSchema).query(({ input }) => {
-        return {
-          skip: input.skip,
-          limit: input.limit,
-          total: 100,
-          data: Array(Math.min(input.limit, 100 - input.skip)).map((_, i) =>
-            createMockAssignment(
-              humanId({
-                separator: "-",
-                capitalize: false,
-              }),
-              `${input.limit + i}번째 과제`,
-            ),
-          ),
-        };
-      }),
+      list,
       // 과제 ID로 과제 세부사항을 봅니다.
-      get: p.input(z.object({ id: z.string() })).query(({ input }) => {
-        if (input.id === "none")
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "해당 ID의 과제를 찾을 수 없습니다.",
-          });
-        return createMockAssignment(input.id, "테스트과제 - id none으로 하면 오류남");
-      }),
+      get,
       // 과제 생성 요청을 합니다. 계정당 하나만 진행할 수 있습니다.
-      generate: p.input(AssignmentPromptSchema).mutation(({ input }) => ({
-        id: humanId({ separator: "-", capitalize: false }),
-        name: "",
-        description: "",
-        readme: "",
-        prompt: input,
-        status: "GENERATING",
-        lastUpdated: new Date().toISOString(),
-      })),
+      generate,
     },
     submission: {
       // 과제 시도를 위한 깃허브 레포지토리를 세팅합니다.
-      init: p.input(SubmissionInitSchema).mutation(
-        (): Submission => ({
-          id: humanId({ separator: "-", capitalize: false }),
-          assignmentId: humanId({ separator: "-", capitalize: false }),
-          status: "PREPARING",
-          lastUpdated: new Date().toISOString(),
-          expiredAt: null,
-        }),
-      ),
+      init,
       // 과제 시도를 취소합니다.
-      cancel: p.input(z.object({ id: z.string() })).mutation((): string => {
-        return humanId({ separator: "-", capitalize: false });
-      }),
+      cancel,
       // 제출물의 파일 목록을 트리 형태로 반환합니다.
-      files: p.input(z.object({ id: z.string() })).query((): ReviewFileTree[] => [
-        {
-          name: "src",
-          type: "directory",
-          path: "src",
-          children: [
-            {
-              name: "index.ts",
-              type: "file",
-              path: "src/index.ts",
-            },
-          ],
-        },
-        {
-          name: "package.json",
-          type: "file",
-          path: "package.json",
-        },
-      ]),
+      files,
       // 제출물의 파일 내용을 반환합니다. 텍스트 형태의 파일만 가능합니다.
-      file: p.input(SubmissionFileRequestSchema).query(
-        (): ReviewFile => ({
-          name: "index.ts",
-          path: "src/index.ts",
-          content: `import z as "zod";
-
-export const TestSchema = z.object({ name: z.string(), });`,
-        }),
-      ),
+      file,
       // 요청한 범위 내의 모든 리뷰 내용을 반환합니다.
-      reviewEntries: p
-        .input(ReviewFilterSchema)
-        .query((): ReviewEntry[] => [
-          ...Array(5).map((_, i) =>
-            createMockReviewEntry(`${i}번 채점 항목`, "summary", undefined, undefined),
-          ),
-          createMockReviewEntry("파일 채점 항목", "lint", "src/index.js", undefined),
-          createMockReviewEntry("라인 채점 항목", "lint", "src/index.js", [10, 13]),
-        ]),
+      reviewEntries,
       // 리뷰의 기본 정보를 반환합니다.
-      review: p.input(z.object({ id: z.string() })).query(
-        ({ input }): Omit<Review, "entries"> => ({
-          id: input.id,
-          status: "DONE",
-          scenarios: [
-            {
-              id: "summary",
-              name: "종합 점수",
-              result: "GOOD",
-              score: 83,
-            },
-            {
-              id: "lint",
-              name: "기본 코드 스타일",
-              result: "FAIL",
-            },
-          ],
-        }),
-      ),
+      review,
     },
   },
 });

--- a/apps/gasi/src/routes/asgmt.ts
+++ b/apps/gasi/src/routes/asgmt.ts
@@ -1,0 +1,42 @@
+import { AssignmentFilterSchema, AssignmentPromptSchema } from "@request/specs";
+import { TRPCError } from "@trpc/server";
+import { humanId } from "human-id";
+import { z } from "zod";
+import { createMockAssignment } from "../mockUtils.js";
+import { p } from "../trpc.js";
+
+export const list = p.input(AssignmentFilterSchema).query(({ input }) => {
+  return {
+    skip: input.skip,
+    limit: input.limit,
+    total: 100,
+    data: Array(Math.min(input.limit, 100 - input.skip)).map((_, i) =>
+      createMockAssignment(
+        humanId({
+          separator: "-",
+          capitalize: false,
+        }),
+        `${input.limit + i}번째 과제`,
+      ),
+    ),
+  };
+});
+
+export const get = p.input(z.object({ id: z.string() })).query(({ input }) => {
+  if (input.id === "none")
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "해당 ID의 과제를 찾을 수 없습니다.",
+    });
+  return createMockAssignment(input.id, "테스트과제 - id none으로 하면 오류남");
+});
+
+export const generate = p.input(AssignmentPromptSchema).mutation(({ input }) => ({
+  id: humanId({ separator: "-", capitalize: false }),
+  name: "",
+  description: "",
+  readme: "",
+  prompt: input,
+  status: "GENERATING",
+  lastUpdated: new Date().toISOString(),
+}));

--- a/apps/gasi/src/routes/auth.ts
+++ b/apps/gasi/src/routes/auth.ts
@@ -1,3 +1,4 @@
+import { RegisterUserRequestSchema } from "@request/specs";
 import { z } from "zod";
 import { kakaoAuthorize } from "../auth/providers.js";
 import { p } from "../trpc.js";
@@ -7,3 +8,5 @@ export const kakao = p
   .query(async ({ input, ctx }) => {
     return await kakaoAuthorize(input.redirectUrl ?? `${ctx.baseUrl}/callback`, input.code);
   });
+
+export const register = p.input(RegisterUserRequestSchema).mutation(() => {});

--- a/apps/gasi/src/routes/auth.ts
+++ b/apps/gasi/src/routes/auth.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { kakaoAuthorize } from "../auth/providers.js";
 import { p } from "../trpc.js";
 
-export const kakao = p.input(z.string()).query(async ({ input, ctx }) => {
-  return await kakaoAuthorize(`${ctx.baseUrl}/callback`, input);
-});
+export const kakao = p
+  .input(z.object({ code: z.string(), redirectUrl: z.string().optional() }))
+  .query(async ({ input, ctx }) => {
+    return await kakaoAuthorize(input.redirectUrl ?? `${ctx.baseUrl}/callback`, input.code);
+  });

--- a/apps/gasi/src/routes/submission.ts
+++ b/apps/gasi/src/routes/submission.ts
@@ -1,0 +1,88 @@
+import {
+  type Review,
+  type ReviewEntry,
+  type ReviewFile,
+  type ReviewFileTree,
+  ReviewFilterSchema,
+  type Submission,
+  SubmissionFileRequestSchema,
+  SubmissionInitSchema,
+} from "@request/specs";
+import { humanId } from "human-id";
+import { z } from "zod";
+import { createMockReviewEntry } from "../mockUtils.js";
+import { p } from "../trpc.js";
+
+export const init = p.input(SubmissionInitSchema).mutation(
+  (): Submission => ({
+    id: humanId({ separator: "-", capitalize: false }),
+    assignmentId: humanId({ separator: "-", capitalize: false }),
+    status: "PREPARING",
+    lastUpdated: new Date().toISOString(),
+    expiredAt: null,
+  }),
+);
+
+export const cancel = p.input(z.object({ id: z.string() })).mutation((): string => {
+  return humanId({ separator: "-", capitalize: false });
+});
+
+export const files = p.input(z.object({ id: z.string() })).query((): ReviewFileTree[] => [
+  {
+    name: "src",
+    type: "directory",
+    path: "src",
+    children: [
+      {
+        name: "index.ts",
+        type: "file",
+        path: "src/index.ts",
+      },
+    ],
+  },
+  {
+    name: "package.json",
+    type: "file",
+    path: "package.json",
+  },
+]);
+
+export const file = p.input(SubmissionFileRequestSchema).query(
+  (): ReviewFile => ({
+    name: "index.ts",
+    path: "src/index.ts",
+    content: `import z as "zod";
+
+export const TestSchema = z.object({ name: z.string(), });`,
+  }),
+);
+
+export const reviewEntries = p
+  .input(ReviewFilterSchema)
+  .query((): ReviewEntry[] => [
+    ...Array(5).map((_, i) =>
+      createMockReviewEntry(`${i}번 채점 항목`, "summary", undefined, undefined),
+    ),
+    createMockReviewEntry("파일 채점 항목", "lint", "src/index.js", undefined),
+    createMockReviewEntry("라인 채점 항목", "lint", "src/index.js", [10, 13]),
+  ]);
+
+export const review = p.input(z.object({ id: z.string() })).query(
+  ({ input }): Omit<Review, "entries"> => ({
+    id: input.id,
+    status: "DONE",
+    scenarios: [
+      {
+        id: "summary",
+        name: "종합 점수",
+        result: "GOOD",
+        score: 83,
+      },
+      {
+        id: "lint",
+        name: "기본 코드 스타일",
+        result: "FAIL",
+      },
+    ],
+  }),
+);

--- a/apps/gasi/src/routes/user.ts
+++ b/apps/gasi/src/routes/user.ts
@@ -1,0 +1,23 @@
+import type { User } from "@request/specs";
+import { p } from "../trpc.js";
+
+export const me = p.query(
+  (): User => ({
+    id: "673f25db6a52140e5bc47f75",
+    name: "구효민",
+    email: "hyomin@soongsil.ac.kr",
+    registered: true,
+    providers: {
+      kakao: {
+        uid: "230549202",
+        connectedAt: "2024-11-21T12:25:34.710Z",
+      },
+    },
+    submissions: [],
+    prompt: {
+      fields: ["프론트엔드", "서버/백엔드"],
+      techs: ["Spring Boot", "Rust"],
+      companies: ["kakao", "goorm"],
+    },
+  }),
+);

--- a/packages/specs/src/context.ts
+++ b/packages/specs/src/context.ts
@@ -1,0 +1,13 @@
+import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify";
+import type { User } from "./schema/user.js";
+
+const defaultBaseUrl = process.env.CLIENT_BASE_URL ?? "http://localhost:3000";
+
+export const createContext = async (
+  opts: CreateFastifyContextOptions,
+): Promise<{ baseUrl: string; user: User | null }> => {
+  return {
+    baseUrl: defaultBaseUrl,
+    user: null,
+  };
+};

--- a/packages/specs/src/trpc.ts
+++ b/packages/specs/src/trpc.ts
@@ -1,4 +1,7 @@
 import { initTRPC } from "@trpc/server";
+import type { createContext } from "./context.js";
 
-export const t = initTRPC.create();
+export type Context = Awaited<ReturnType<typeof createContext>>;
+
+export const t = initTRPC.context<Context>().create();
 export const p = t.procedure;


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

요청 스키마가 string을 직접 받아 어떤 값을 받는지 명확하지 않은 경우가 있습니다. `string`을 직접 받지 않고 object를 통해 받도록 수정하였습니다.

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
