### PR TITLE
feat(client): 동적 ID를 사용하여 평가 결과 정보 쿼리 수정 및 마크다운 페이지 코드 정리  @minai621

### DIFF
--- a/apps/client/src/features/evaluation/ui/evaluation-comment.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-comment.tsx
@@ -31,16 +31,14 @@ const EvaluationComment = () => {
             분석 코멘트는 아래와 같은 기준에 따라 작성되었어요.
           </Typography>
         </div>
-        <div className="space-y-10">
+        {/* <div className="space-y-10">
           <div className="p-12 border border-[#DEDEDE] rounded-3xl">
-            <Markdown source={`# ${reviewEntriesData?.[0].name}` || ""} />
-          </div>
-          {/* <div className="p-12 border border-[#DEDEDE] rounded-3xl"></div> */}
-          <div className="p-12 bg-primary rounded-3xl text-white">
             <Markdown source={`# ${reviewData?.summary}` || ""} />
-            {/* <Markdown source={`# ${reviewEntriesData?.[0].name}` || ""} /> */}
           </div>
-        </div>
+          <div className="p-12 bg-primary rounded-3xl text-white">
+            <Markdown source={reviewData?.summary || ""} />
+          </div>
+        </div> */}
       </section>
     </>
   );

--- a/apps/client/src/features/evaluation/ui/evaluation-item.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-item.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 
 export interface EvaluationItemProps extends Omit<Assignment, "status"> {
   status: SubmissionStatus;
+  submissionId: string;
 }
 
 export default function EvaluationItem(props: EvaluationItemProps) {
@@ -24,7 +25,7 @@ export default function EvaluationItem(props: EvaluationItemProps) {
   ];
 
   const handleRouteToResult = () => {
-    router.push(`/evaluation/${props?.id}`);
+    router.push(`/evaluation/${props?.submissionId}`);
   };
 
   return (

--- a/apps/client/src/features/evaluation/ui/evaluation-overall-score.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-overall-score.tsx
@@ -30,7 +30,8 @@ const EvaluationOverallScore = () => {
     <>
       <div className="space-y-1">
         <Typography as="p" size="xl" weight="bold">
-          내 과제 종합 점수는 <span className="text-primary">{overallScore || 0}점</span> 이에요
+          내 과제 종합 점수는{" "}
+          <span className="text-primary">{Math.floor(overallScore) || 0}점</span> 이에요
         </Typography>
         <Typography as="p" weight="semibold" className="text-[#939393]">
           {commentByScore(overallScore || 0)}

--- a/apps/client/src/features/evaluation/ui/evaluation-result-info.tsx
+++ b/apps/client/src/features/evaluation/ui/evaluation-result-info.tsx
@@ -2,9 +2,12 @@
 
 import { trpc } from "@/shared/api/trpc";
 import Typography from "@/shared/ui/common/typography/typography";
+import { useParams } from "next/navigation";
 
 const EvaluationResultInfo = () => {
-  const { data: assginmentData } = trpc.v1.asgmt.get.useQuery({ id: "1" });
+  const parmas = useParams();
+  const id = (parmas?.id as string) || "1";
+  const { data: assginmentData } = trpc.v1.asgmt.get.useQuery({ id });
   const category = assginmentData?.prompt.fields.join(" / ");
 
   return (

--- a/apps/client/src/features/evaluation/ui/ongoing-assignment.tsx
+++ b/apps/client/src/features/evaluation/ui/ongoing-assignment.tsx
@@ -14,8 +14,6 @@ interface OngoingAssignmentProps
 }
 
 export default function OngoingAssignment(props: OngoingAssignmentProps) {
-  console.log(props);
-
   const isStarted = props?.status === "STARTED";
   const allPrompts = [
     ...(props?.prompt?.fields || []),

--- a/apps/client/src/pages/evaluation/evaluation-page.tsx
+++ b/apps/client/src/pages/evaluation/evaluation-page.tsx
@@ -26,16 +26,21 @@ const EvaluationPage = () => {
     name: assignmentData?.name,
     lastUpdated: assignmentData?.lastUpdated,
   };
-  const filteredRestAssignments = assignmentList?.data.filter((assignment, idx) => {
-    const find = restSubmissions?.find((rest) => rest.assignmentId === assignment.id);
-    if (find) {
-      return {
-        ...assignmentList.data[idx],
-        status: assignment.status,
-        submissionId: find.id,
-      };
-    }
-  });
+  const filteredRestAssignments = assignmentList?.data
+    .map((assignment, idx) => {
+      const find = restSubmissions?.find((rest) => rest.assignmentId === assignment.id);
+      console.log(find);
+      if (find) {
+        return {
+          ...assignmentList.data[idx],
+          status: assignment.status,
+          submissionId: find.id,
+        };
+      }
+      return null;
+    })
+    .filter((assignment) => assignment !== null);
+
 
   return (
     <Flex as="main" direction="col" className="w-full px-24 py-14">

--- a/apps/client/src/pages/markdown.tsx
+++ b/apps/client/src/pages/markdown.tsx
@@ -7,42 +7,21 @@ interface MarkdownProps {
   source?: string;
 }
 
+function isSpace(code: number) {
+  switch (code) {
+    case 0x09:
+    case 0x20:
+      return true;
+  }
+  return false;
+}
+
+window.isSpace = isSpace;
+
 function Markdown({ source }: MarkdownProps) {
   const mdRef = useRef<HTMLDivElement>(null);
   const md = MarkdownIt();
-  // const result = md.render(source || "");
-  const result = md.render(`
-    # 코드 평가
-
-## 전체적인 코드 구조
-
-### 잘된 점
-
-1. 타입스크립트 사용:
-   - 모든 파일들이 타입스크립트를 사용하여 구현된 점은 고무적입니다. 타입스크립트는 타입 체크를 통해 런타임 오류를 줄여주며, 코드의 가독성 및 유지보수성을 높여줍니다.
-
-2. MVC 패턴의 적용:
-   - 전체 프로젝트가 MVC 패턴을 따라 구조화된 점이 우수합니다. 이는 코드의 역할을 명확히 구분하고, 구조적인 접근 방식을 통해 장기적으로 유지 보수에 용이합니다.
-
-3. 파일 구조:
-   - 디렉토리가 /app/src/project/src/routes, /app/src/project/src/models, /app/src/project/src/services 등으로 분리되어 있어 모듈화와 코드 명확성을 높이며, 서비스별 책임을 분리한 점이 인상적입니다.
-
-### 개선이 필요한 점
-
-1. 디렉토리 네이밍:
-   - loaders와 splitters가 DataIngestion 내부에 있지만, 각각의 기능을 좀 더 세분화해서 ingestion-loaders와 ingestion-splitters 같은 구체적인 이름으로 디렉토리를 구분하면 명확성을 더할 수 있습니다.
-
-2. 코드 중복 제거:
-   - 비슷한 코드들이 여러 서비스에 중복되어 있을 가능성이 높습니다. PDF, DOCX 파일 로더에서 공통적으로 처리하는 부분은 별도로 추출하여 재사용하면 유지보수성을 높일 수 있습니다.
-
-## 세부 사항 분석
-
-### 잘된 점
-
-1. 데이터 로더 구현:
-   - 다양한 파일 형식을 지원하는 로더(pdf-loader.ts, docx-loader.ts, notion-loader.ts, web-loader.ts)가 잘 구현되어
-
-  `);
+  const result = md.render(source || "");
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {

--- a/apps/client/src/pages/markdown.tsx
+++ b/apps/client/src/pages/markdown.tsx
@@ -10,7 +10,39 @@ interface MarkdownProps {
 function Markdown({ source }: MarkdownProps) {
   const mdRef = useRef<HTMLDivElement>(null);
   const md = MarkdownIt();
-  const result = md.render(source || "");
+  // const result = md.render(source || "");
+  const result = md.render(`
+    # 코드 평가
+
+## 전체적인 코드 구조
+
+### 잘된 점
+
+1. 타입스크립트 사용:
+   - 모든 파일들이 타입스크립트를 사용하여 구현된 점은 고무적입니다. 타입스크립트는 타입 체크를 통해 런타임 오류를 줄여주며, 코드의 가독성 및 유지보수성을 높여줍니다.
+
+2. MVC 패턴의 적용:
+   - 전체 프로젝트가 MVC 패턴을 따라 구조화된 점이 우수합니다. 이는 코드의 역할을 명확히 구분하고, 구조적인 접근 방식을 통해 장기적으로 유지 보수에 용이합니다.
+
+3. 파일 구조:
+   - 디렉토리가 /app/src/project/src/routes, /app/src/project/src/models, /app/src/project/src/services 등으로 분리되어 있어 모듈화와 코드 명확성을 높이며, 서비스별 책임을 분리한 점이 인상적입니다.
+
+### 개선이 필요한 점
+
+1. 디렉토리 네이밍:
+   - loaders와 splitters가 DataIngestion 내부에 있지만, 각각의 기능을 좀 더 세분화해서 ingestion-loaders와 ingestion-splitters 같은 구체적인 이름으로 디렉토리를 구분하면 명확성을 더할 수 있습니다.
+
+2. 코드 중복 제거:
+   - 비슷한 코드들이 여러 서비스에 중복되어 있을 가능성이 높습니다. PDF, DOCX 파일 로더에서 공통적으로 처리하는 부분은 별도로 추출하여 재사용하면 유지보수성을 높일 수 있습니다.
+
+## 세부 사항 분석
+
+### 잘된 점
+
+1. 데이터 로더 구현:
+   - 다양한 파일 형식을 지원하는 로더(pdf-loader.ts, docx-loader.ts, notion-loader.ts, web-loader.ts)가 잘 구현되어
+
+  `);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->
